### PR TITLE
Fixing the broken code.

### DIFF
--- a/git-jenkins-console/Program.cs
+++ b/git-jenkins-console/Program.cs
@@ -12,8 +12,7 @@ namespace git_jenkins_console
         {
             if (args == null) throw new ArgumentNullException("args");
 
-            //Braking the build to test build failure on Jenkins
-            if (args.Length == 0) throw new ArgumenOutOfangeException("args");
+            if (args.Length == 0) throw new ArgumentOutOfRangeException("args");
 
             Console.WriteLine(SayHello(args[0]));
         }


### PR DESCRIPTION
Previusly the code was broken on purpose to provide a way to test effectivli the Jenkins is working correctly detectin broken builds.